### PR TITLE
fix: docker-compose services

### DIFF
--- a/template/backend/docker-compose.override.yml
+++ b/template/backend/docker-compose.override.yml
@@ -1,0 +1,1 @@
+services: {}

--- a/template/backend/docker-compose.yml
+++ b/template/backend/docker-compose.yml
@@ -43,8 +43,5 @@ services:
     container_name: ambev_developer_evaluation_cache 
     image: redis:7.4.1-alpine     
     command: redis-server --requirepass ev@luAt10n
-    environment:
-       MONGO_INITDB_ROOT_USERNAME: developer
-       MONGO_INITDB_ROOT_PASSWORD: ev@luAt10n
     ports:
        - "6379"


### PR DESCRIPTION
- add a minimal valid YAML structure to "docker-compose.override" file
- incorrect environment variables in the Redis service